### PR TITLE
Support for using TLOG and PULL replicas

### DIFF
--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -133,7 +133,7 @@ public class BenchmarksMain {
                             log.warn("Error trying to delete collection: " + ex);
                         }
                         solrCloud.uploadConfigSet(setup.configset);
-                        solrCloud.createCollection(setup.collection, setup.configset, setup.shards, setup.replicationFactor);
+                        solrCloud.createCollection(setup);
                         long start = System.nanoTime();
                         index(solrCloud.nodes.get(0).getBaseUrl(), setup.collection, i, benchmark);
                         long end = System.nanoTime();

--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -53,7 +53,16 @@ public class IndexBenchmark {
     public String configset;
 
     @JsonProperty("replication-factor")
-    public int replicationFactor;
+    public Integer replicationFactor;
+
+    @JsonProperty("nrt-replicas")
+    public Integer nrtReplicas;
+
+    @JsonProperty("tlog-replicas")
+    public Integer tlogReplicas;
+    
+    @JsonProperty("pull-replicas")
+    public Integer pullReplicas;
 
     @JsonProperty("shards")
     public int shards;

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.benchmarks.beans.Cluster;
+import org.apache.solr.benchmarks.beans.IndexBenchmark;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -128,14 +129,19 @@ public class SolrCloud {
    * @param replicas
    * @throws Exception 
    */
-  public void createCollection(String collectionName, String configName, int shards, int replicas) throws Exception {
+  public void createCollection(IndexBenchmark.Setup setup) throws Exception {
 	  try (HttpSolrClient hsc = createClient()) {
-		  Create create = Create.createCollection(collectionName, configName, shards, replicas);
+		  Create create;
+		  if (setup.replicationFactor != null) {
+			  create = Create.createCollection(setup.collection, setup.configset, setup.shards, setup.replicationFactor);
+		  } else {
+			  create = Create.createCollection(setup.collection, setup.configset, setup.shards,
+					  setup.nrtReplicas, setup.tlogReplicas, setup.pullReplicas);
+		  }
 		  CollectionAdminResponse resp = create.process(hsc);
-		  log.info("");
 		  log.info("Collection created: "+ resp.jsonStr());
       }
-	  colls.add(collectionName);
+	  colls.add(setup.collection);
   }
 
   HttpSolrClient createClient() {


### PR DESCRIPTION
The configurations should either have
(a) "replication-factor" or,
(b) one or more of "nrt-replicas", "tlog-replicas" or "pull-replicas".